### PR TITLE
Add support for pre-commit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -52,7 +52,8 @@ def run_checks(pr_url, config_file=None, details_url=None):
 @click.option('-p', '--pr-url', required=False, type=str)
 @click.option('-c', '--config-file', required=False, type=str)
 @click.option('--details-url', required=False, type=str)
-def main(pr_url, config_file=None, details_url=None):
+@click.argument('args', nargs=-1)
+def main(pr_url, config_file=None, details_url=None, args=None):
     """Run all checks described in `config_file`.
 
     If a URL of a pull request is given, it performs all checks on it.
@@ -67,5 +68,6 @@ def main(pr_url, config_file=None, details_url=None):
     :param str config_file: the path of the configuration file,
         formatted in YAML, as found in contrib/config/sample.yml
     :param str details_url: the URL to visit for more details about the results
+    :param list args: necessary for pre-commit support
     """
     run_checks(pr_url=pr_url, config_file=config_file, details_url=details_url)


### PR DESCRIPTION
`.pre-commit-hooks.yml` file had already been committed (much) earlier.

See www.pre-commit.com for more information.