### PR TITLE
Add real support for pre-commit

### DIFF
--- a/temcheck/checks/config.py
+++ b/temcheck/checks/config.py
@@ -142,7 +142,7 @@ class ConfigFactory:
     configuration for the whole library."""
 
     @staticmethod
-    def create(config_dict: dict, include_pr: bool=True) -> Config:
+    def create(config_dict: dict, include_pr: bool = True) -> Config:
         """Create a new Config object.
 
         :param dict config_dict: a dictionary with the full configuration

--- a/temcheck/checks/results.py
+++ b/temcheck/checks/results.py
@@ -25,7 +25,9 @@ ERROR_INVALID_COMMIT_MESSAGE_FORMAT = 'invalid_commit_message_format'
 class CheckResult:
     """Contains the results of a single Check that was performed."""
 
-    def __init__(self, config: CheckConfig, status: str, error_code: str=None, **details):
+    def __init__(
+        self, config: CheckConfig, status: str, error_code: str = None, **details
+    ):
         """Constructor.
 
         :param CheckConfig config: the related configuration with which the

--- a/temcheck/checks/suite.py
+++ b/temcheck/checks/suite.py
@@ -22,7 +22,12 @@ class CheckSuite:
     All checks run synchronously.
     """
 
-    def __init__(self, config: Config, content_provider_factory: BaseGitContentProviderFactory, check_factory: CheckFactory):
+    def __init__(
+        self,
+        config: Config,
+        content_provider_factory: BaseGitContentProviderFactory,
+        check_factory: CheckFactory,
+    ):
         """Constructor.
 
         :param Config config: an object that contains all configuration options,

--- a/temcheck/git/content.py
+++ b/temcheck/git/content.py
@@ -1,4 +1,5 @@
 import os
+import re
 from functools import lru_cache
 from typing import Type, Union
 
@@ -108,4 +109,107 @@ class GitContentProviderFactory(BaseGitContentProviderFactory):
         return {
             TYPE_BRANCH_NAME: BranchContentProvider,
             TYPE_COMMIT_MESSAGE: CommitsContentProvider,
+        }
+
+
+class PreCommitBranchContentProvider(BaseContentProvider):
+    @lru_cache(maxsize=None)
+    def get_content(self) -> dict:
+        """Return a dictionary that contains the current branch name.
+
+        :return: the current branch name, in a dictionary like:
+            {'branch': <branch_name>}
+        :rtype: dict
+        """
+        repo = Repo(os.getcwd())
+        branch_name = repo.head.ref.name
+        return {'branch': branch_name}
+
+
+class PreCommitCommitsContentProvider(BaseContentProvider):
+    @lru_cache(maxsize=None)
+    def get_content(self) -> dict:
+        """Return a dictionary that contains information about
+        the pending commit of the current branch.
+
+        :return: the information in a dictionary format as follows:
+            {
+              'commits': [
+                {
+                  'message': <message>,
+                  'sha': ',
+                  'url': '',
+                  'stats': {
+                    'additions': <total_additions>,
+                    'deletions': <total_deletions>,
+                    'total': <total_lines>,
+                  },
+                },
+              ],
+            }
+        :rtype: dict
+        """
+        repo = Repo(os.getcwd())
+        git_dir = repo.git_dir
+
+        # Find the pending commit message
+        commit_msg_filepath = os.path.join(git_dir, 'COMMIT_EDITMSG')
+        with open(commit_msg_filepath, 'r') as f:
+            content = f.read()
+
+        # Get the commit statistics
+        diff = repo.git.diff('--cached', '--shortstat')
+        regex = (
+            '\s+(\d+) files? changed, '
+            '(\d+) insertions?\(\+\), (\d+) deletions?\(\-\)'
+        )
+        result = re.match(regex, diff)
+        if result:
+            insertions = int(result.group(2))
+            deletions = int(result.group(3))
+        else:
+            insertions, deletions = 0, 0
+
+        return {
+            'commits': [
+                {
+                    'message': content,
+                    'sha': '',
+                    'url': '',
+                    'stats': {
+                        'additions': insertions,
+                        'deletions': deletions,
+                        'total': insertions + deletions,
+                    },
+                }
+            ]
+        }
+
+
+class PreCommitContentProviderFactory(BaseGitContentProviderFactory):
+    """Responsible for creating the proper content provider for every type of check,
+    specifically for local Git repositories amd a pre-commit setting.
+
+    Allows clients to add custom functionality by registering new providers,
+    associated with certain configuration types.
+    """
+
+    def create(self, check: Check) -> Union[BaseContentProvider, None]:
+        """Return a content provider that can later provide all required content
+        for a certain check to execute its actions.
+
+        :param Check check: the check object to create a content provider for
+        :return: a content provider
+        :rtype: BaseContentProvider
+        """
+        cls: Type[BaseContentProvider] = self._providers.get(check.check_type, None)
+        if cls is None:
+            return None
+
+        return cls()
+
+    def _get_defaults(self) -> dict:
+        return {
+            TYPE_BRANCH_NAME: PreCommitBranchContentProvider,
+            TYPE_COMMIT_MESSAGE: PreCommitCommitsContentProvider,
         }

--- a/temcheck/github/content.py
+++ b/temcheck/github/content.py
@@ -85,7 +85,7 @@ class GithubPRContentProvider(GithubContentProvider):
             return {}
         return github_service().create_pr_comment(self.repo_name, self.pr_number, body)
 
-    def delete_previous_pr_comment(self, latest_comment_id: int)-> bool:
+    def delete_previous_pr_comment(self, latest_comment_id: int) -> bool:
         """Delete the previous temcheck comment on the PR.
 
         Only deletes 1 comment. `latest_comment_id` is given

--- a/temcheck/reporting/__init__.py
+++ b/temcheck/reporting/__init__.py
@@ -6,7 +6,7 @@ class StringBuilder:
     def __init__(self):
         self.strings = []
 
-    def add(self, string: str=''):
+    def add(self, string: str = ''):
         """Add a new line."""
         self.strings.append(string)
 

--- a/temcheck/reporting/pr.py
+++ b/temcheck/reporting/pr.py
@@ -12,7 +12,7 @@ class PRCommentReport:
 
     TITLE = '# Pull Request Health Check'
 
-    def __init__(self, suite: CheckSuite, details_url: str=None):
+    def __init__(self, suite: CheckSuite, details_url: str = None):
         """Constructor.
 
         :param CheckSuite suite: the check suite that was executed


### PR DESCRIPTION
Add a new mode, which should be executed on a pre-commit hook. It takes into account the pending commit only (and the current branch).

Previous implementation of pre-commit functionality checked all commits of the current branch, not just the pending commit.

