### PR TITLE
Fix wrong path of default config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -29,7 +29,8 @@ def run_checks(
         if os.path.isfile('.totem.yml'):
             config_file = '.totem.yml'
         else:
-            config_file = './contrib/config/default.yml'
+            package_root = os.path.split(__file__)[0]
+            config_file = os.path.join(package_root, 'contrib/config/default.yml')
     try:
         with open(config_file, 'r') as f:
             try:

--- a/totem/__init__.py
+++ b/totem/__init__.py
@@ -1,5 +1,5 @@
 
-from ._version import get_versions
+from totem._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions

--- a/versioneer.py
+++ b/versioneer.py
@@ -285,7 +285,7 @@ import re
 import subprocess
 import sys
 
-from ._version import get_versions
+from totem._version import get_versions
 
 try:
     import configparser


### PR DESCRIPTION
The default YAML configuration wasn't being loaded at all, if no config file was found or provided. The previous path was pointing to the current directory, instead of the package (Totem) directory.

Change the path to point to the proper file, so that Totem can work with sensible defaults.