### PR TITLE
Fix exception on merge commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
         command: pip install git+ssh://git@github.com/transifex/totem.git@devel
     - run:
         name: Run totem
-        command: totem --pr-url $CIRCLE_PULL_REQUEST --config-file .totem.yml --details-url $CIRCLE_BUILD_URL
+        command: totem --pr-url "$CIRCLE_PULL_REQUEST" --config-file ".totem.yml" --details-url "$CIRCLE_BUILD_URL"
 
   build:
     working-directory: ~/transifex/totem

--- a/totem/main.py
+++ b/totem/main.py
@@ -29,7 +29,7 @@ from totem.checks.suite import CheckSuite
 from totem.git.content import GitContentProviderFactory, PreCommitContentProviderFactory
 from totem.github.content import GithubContentProviderFactory, GithubPRContentProvider
 from totem.github.utils import parse_pr_url
-from totem.reporting.console import LocalConsoleReport, PRConsoleReport
+from totem.reporting.console import Color, LocalConsoleReport, PRConsoleReport
 from totem.reporting.pr import PRCommentReport
 
 
@@ -136,7 +136,16 @@ class PRCheck(BaseCheck):
 
         self.pr_url = pr_url
         self.details_url = details_url
-        self.full_repo_name, self.pr_number = parse_pr_url(pr_url)
+        try:
+            self.full_repo_name, self.pr_number = parse_pr_url(pr_url)
+        except IndexError:
+            print(
+                Color.format(
+                    '[error]PR URL cannot be parsed, '
+                    'seems invalid: "{}"[end]'.format(pr_url)
+                )
+            )
+            raise
         self._content_provider_factory = GithubContentProviderFactory(
             self.full_repo_name, self.pr_number
         )


### PR DESCRIPTION
When running on a merge commit, there is no PR URL anymore. Therefore, the command uses an empty string as a URL. The way the command was, the value of the `--pr-url` argument became `--config-file`, which was neither an empty string nor a valid value.

Because it wasn't blank, the PRCheck run. But the URL was not valid, so an exception occurred when trying to parse it.