### PR TITLE
Fix error when running on a detached head

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -49,18 +49,27 @@ def run_checks(
 
     print(
         'Running with arguments:\n'
-        ' - PR URL: "{pr_url}"\n'
-        ' - Config file path: "{config_file}"\n'
-        ' - Details URL: "{details_url}"'.format(
-            pr_url=pr_url, config_file=config_file, details_url=details_url
+        ' - PR URL: {pr_url}\n'
+        ' - Config file path: {config_file}\n'
+        ' - Details URL: {details_url}'.format(
+            pr_url=pr_url if pr_url is None else '"{}"'.format(pr_url),
+            config_file=(
+                config_file if config_file is None else '"{}"'.format(config_file)
+            ),
+            details_url=(
+                details_url if details_url is None else '"{}"'.format(details_url)
+            ),
         )
     )
     if pr_url:
+        print('Running in PRCheck mode')
         check = PRCheck(config_dict=config, pr_url=pr_url, details_url=details_url)
     else:
         if not arguments:
+            print('Running in LocalCheck mode')
             check = LocalCheck(config_dict=config)
         else:
+            print('Running in PreCommitLocalCheck mode')
             check = PreCommitLocalCheck(config_dict=config)
 
     results = check.run()

--- a/tests/checks/test_checks.py
+++ b/tests/checks/test_checks.py
@@ -17,6 +17,7 @@ from totem.checks.results import (
     ERROR_MISSING_PR_BODY_TEXT,
     ERROR_UNFINISHED_CHECKLIST,
     STATUS_ERROR,
+    STATUS_PASS,
 )
 
 
@@ -47,9 +48,18 @@ class TestBranchNameCheck:
         assert result.success is False
         assert result.error_code == ERROR_INVALID_BRANCH_NAME
 
-    def test_missing_branch_returns_error(self):
+    def test_missing_branch_returns_success(self):
         check = BranchNameCheck(CheckConfig('branch_name', 'error'))
-        result = check.run({})  # no 'branch' entry
+        result = check.run({'branch': None})
+        assert result.status == STATUS_PASS
+        assert result.details['message'] == (
+            'Branch name not available, skipping branch name validation '
+            '(could be a detached head)'
+        )
+
+    def test_empty_branch_returns_error(self):
+        check = BranchNameCheck(CheckConfig('branch_name', 'error'))
+        result = check.run({'branch': ''})
         assert result.status == STATUS_ERROR
         assert result.error_code == ERROR_INVALID_CONTENT
         assert result.details['message'] == 'Branch name not defined or empty'

--- a/totem/checks/checks.py
+++ b/totem/checks/checks.py
@@ -44,6 +44,12 @@ class BranchNameCheck(Check):
         pattern = self._from_config('pattern')
         branch_name = content.get('branch')
 
+        if branch_name is None:
+            return self._get_success(
+                message='Branch name not available, skipping branch name validation '
+                        '(could be a detached head)'
+            )
+
         if not branch_name:
             return self._get_error(
                 ERROR_INVALID_CONTENT, message='Branch name not defined or empty'

--- a/totem/git/content.py
+++ b/totem/git/content.py
@@ -19,7 +19,11 @@ class BranchContentProvider(BaseContentProvider):
         :rtype: dict
         """
         repo = Repo(os.getcwd())
-        branch_name = repo.head.ref.name
+        if repo.head.is_detached:
+            branch_name = None
+        else:
+            branch_name = repo.head.ref.name
+        
         return {'branch': branch_name}
 
 
@@ -50,7 +54,10 @@ class CommitsContentProvider(BaseContentProvider):
         :rtype: dict
         """
         repo = Repo(os.getcwd())
-        branch_name = repo.head.ref.name
+        if repo.head.is_detached:
+            branch_name = repo.head.commit.hexsha
+        else:
+            branch_name = repo.head.ref.name
         last_commit = repo.commit(branch_name)
         parent_ref = last_commit.parents[0]
 


### PR DESCRIPTION
If the checks were running on a detached head, they failed with the following error: "HEAD is a detached symbolic reference as it points to..."

Now in this case the commit is retrieved properly for commit-based checks and the branch name check is ignored.

Also print more info when running.