### PR TITLE
Always show results in local mode

### DIFF
--- a/.totem.yml
+++ b/.totem.yml
@@ -16,7 +16,7 @@ settings:
     show_empty_sections: False
     show_message: True
     show_details: True
-    show_successful: False
+    show_successful: True
 checks:
   branch_name:
     pattern: ^[\w\d\-]+$

--- a/totem/main.py
+++ b/totem/main.py
@@ -287,9 +287,7 @@ class LocalCheck(BaseCheck):
         suite.run()
 
         report = LocalConsoleReport(suite)
-        show_warnings = report.report_details.get('show_warnings', True)
-        if suite.results.errors or (show_warnings and suite.results.warnings):
-            print(report.get_detailed_results(suite.results))
+        print(report.get_detailed_results(suite.results))
 
         return suite.results
 


### PR DESCRIPTION
If the configuration allows it, show the results, even if all is successful.