### PR TITLE
Avoid running Totem on master and devel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,27 @@ jobs:
     - run:
         name: Install totem
         command: pip install git+ssh://git@github.com/transifex/totem.git@devel
+    # The pull request string can be empty for 2 reasons:
+    #   1. This is a merge commit, so there is currently no PR
+    #   2. A bug of CircleCI does not populate the PR variable
+    # We cannot know for sure why this has happened. We check the current
+    # branch and if it's not `master` or `devel`, then we assume
+    # we've hit the bug.
     - run:
-        name: Run totem
-        command: totem --pr-url "$CIRCLE_PULL_REQUEST" --config-file ".totem.yml" --details-url "$CIRCLE_BUILD_URL"
+        name: Run Totem
+        command: |
+          if [[ "$CIRCLE_BRANCH" == "devel" || "$CIRCLE_BRANCH" == "master" ]]; then
+            echo "Totem is disabled on branch '$CIRCLE_BRANCH'. Won't execute."
+          else
+            if [[ "$CIRCLE_PULL_REQUEST" == "" ]]; then
+              echo "\$CIRCLE_PULL_REQUEST is empty. It's probably due to CircleCI's bug"
+              echo "(https://discuss.circleci.com/t/circle-pull-request-not-being-set/14409)."
+              echo "Please rerun the workflow until the PR variable is populated by CircleCI."
+              exit 1
+            else
+              totem --pr-url "$CIRCLE_PULL_REQUEST" --config-file ".totem.yml" --details-url "$CIRCLE_BUILD_URL"
+            fi
+          fi
 
   build:
     working-directory: ~/transifex/totem


### PR DESCRIPTION
Previously Totem ran whenever there was a new commit, including when a PR was merged into the base branch. Because in that case there was no pull request info in CircleCI's $PULL_REQUEST, Totem used a mode that checked all commits of that branch. Because the branch would probably include merge commits, the commit messages were too long and Totem failed (e.g. "Merge pull request #108 from <branch-name>").

Now the CI script does not run Totem at all if the current branch is either `devel` or `master`, so we won't be having problems with Totem failing after merging a PR on those branches.

Note that this issue will still occur when merging a PR on other branches. As this happens much more rarely in our current workflow, this is not considered to be an issue.