### PR TITLE
Check improvements

### DIFF
--- a/.totem.yml
+++ b/.totem.yml
@@ -36,6 +36,7 @@ checks:
       pattern_descr: Commit message subject must start with a capital letter and must not finish with a dot
     body:
       max_line_length: 72
+      ignore_urls: True
       smart_require:
         min_changes: 100
         min_body_lines: 1

--- a/cli.py
+++ b/cli.py
@@ -13,6 +13,7 @@ def run_checks(
     pr_url: str,
     config_file: str = None,
     details_url: str = None,
+    checks: str = '',
     arguments: list = None,
 ):
     """Run all checks described in `config_file` for the PR on the given URL.
@@ -21,6 +22,7 @@ def run_checks(
     :param str config_file: the path of the configuration file,
         formatted in YAML, as found in contrib/config/sample.yml
     :param str details_url: the URL to visit for more details about the results
+    :param str checks: comma separated list of check IDs to run
     :param list arguments: a list of optional arguments; if the list is empty,
         all commits of the current branch will be checked; otherwise,
         only the pending commit will be checked (as in a pre-commit fashion)
@@ -51,11 +53,13 @@ def run_checks(
         'Running with arguments:\n'
         ' - PR URL: {pr_url}\n'
         ' - Config file path: {config_file}\n'
+        ' - Checks: {checks}\n'
         ' - Details URL: {details_url}'.format(
             pr_url=pr_url if pr_url is None else '"{}"'.format(pr_url),
             config_file=(
                 config_file if config_file is None else '"{}"'.format(config_file)
             ),
+            checks=checks,
             details_url=(
                 details_url if details_url is None else '"{}"'.format(details_url)
             ),
@@ -72,7 +76,8 @@ def run_checks(
             print('Running in PreCommitLocalCheck mode')
             check = PreCommitLocalCheck(config_dict=config)
 
-    results = check.run()
+    check_ids = checks.split(',') if checks else None
+    results = check.run(checks=check_ids)
     if results.errors:
         sys.exit(1)
 
@@ -81,9 +86,14 @@ def run_checks(
 @click.option('-p', '--pr-url', required=False, type=str)
 @click.option('-c', '--config-file', required=False, type=str)
 @click.option('--details-url', required=False, type=str)
+@click.option('--checks', required=False, type=str)
 @click.argument('args', nargs=-1)
 def main(
-    pr_url: str, config_file: str = None, details_url: str = None, args: list = None
+    pr_url: str,
+    config_file: str = None,
+    details_url: str = None,
+    checks: str = None,
+    args: list = None,
 ):
     """Run all checks described in `config_file`.
 
@@ -99,8 +109,13 @@ def main(
     :param str config_file: the path of the configuration file,
         formatted in YAML, as found in contrib/config/sample.yml
     :param str details_url: the URL to visit for more details about the results
+    :param str checks: comma separated list of check IDs to run
     :param list args: necessary for pre-commit support
     """
     run_checks(
-        pr_url=pr_url, config_file=config_file, details_url=details_url, arguments=args
+        pr_url=pr_url,
+        config_file=config_file,
+        details_url=details_url,
+        checks=checks,
+        arguments=args,
     )

--- a/tests/checks/test_checks.py
+++ b/tests/checks/test_checks.py
@@ -26,10 +26,10 @@ class TestBranchNameCheck:
 
     def test_default_config(self):
         check = BranchNameCheck(CheckConfig('branch_name', 'error'))
-        result = check.run({'branch': 'some-thing-3-yo'})
+        result = check.run({'branch': 'some-thing-3-yo'})[0]
         assert result.success is True
 
-        result = check.run({'branch': 'invalid##name'})
+        result = check.run({'branch': 'invalid##name'})[0]
         assert result.success is False
         assert result.error_code == ERROR_INVALID_BRANCH_NAME
 
@@ -37,20 +37,20 @@ class TestBranchNameCheck:
         check = BranchNameCheck(
             CheckConfig('branch_name', 'error', pattern='^[abc99]+$')
         )
-        result = check.run({'branch': 'ab9c9bb9ca9aa'})
+        result = check.run({'branch': 'ab9c9bb9ca9aa'})[0]
         assert result.success is True
 
-        result = check.run({'branch': 'ab9c9bb9-ca9aa'})
+        result = check.run({'branch': 'ab9c9bb9-ca9aa'})[0]
         assert result.success is False
         assert result.error_code == ERROR_INVALID_BRANCH_NAME
 
-        result = check.run({'branch': 'db9c9bb9ca9aa'})
+        result = check.run({'branch': 'db9c9bb9ca9aa'})[0]
         assert result.success is False
         assert result.error_code == ERROR_INVALID_BRANCH_NAME
 
     def test_missing_branch_returns_success(self):
         check = BranchNameCheck(CheckConfig('branch_name', 'error'))
-        result = check.run({'branch': None})
+        result = check.run({'branch': None})[0]
         assert result.status == STATUS_PASS
         assert result.details['message'] == (
             'Branch name not available, skipping branch name validation '
@@ -59,7 +59,7 @@ class TestBranchNameCheck:
 
     def test_empty_branch_returns_error(self):
         check = BranchNameCheck(CheckConfig('branch_name', 'error'))
-        result = check.run({'branch': ''})
+        result = check.run({'branch': ''})[0]
         assert result.status == STATUS_ERROR
         assert result.error_code == ERROR_INVALID_CONTENT
         assert result.details['message'] == 'Branch name not defined or empty'
@@ -69,7 +69,7 @@ class TestBranchNameCheck:
             check = BranchNameCheck(
                 CheckConfig('branch_name', 'error', pattern=pattern)
             )
-            result = check.run({'branch': 'something'})
+            result = check.run({'branch': 'something'})[0]
             assert result.status == STATUS_ERROR
             assert result.error_code == ERROR_INVALID_CONFIG
             assert (
@@ -84,40 +84,40 @@ class TestPRTItle:
     def test_default_config(self):
         check = PRTitleCheck(CheckConfig('whatever', 'error'))
 
-        result = check.run({'title': 'Upper first letter - 3233'})
+        result = check.run({'title': 'Upper first letter - 3233'})[0]
         assert result.success is True
 
-        result = check.run({'title': 'ALL CAPS'})
+        result = check.run({'title': 'ALL CAPS'})[0]
         assert result.success is True
 
-        result = check.run({'title': 'lowercase THEN CAPS'})
+        result = check.run({'title': 'lowercase THEN CAPS'})[0]
         assert result.success is False
         assert result.error_code == ERROR_INVALID_PR_TITLE
 
     def test_custom_config(self):
         check = PRTitleCheck(CheckConfig('title', 'error', pattern='^[abc99]+$'))
 
-        result = check.run({'title': 'ab9c9bb9ca9aa'})
+        result = check.run({'title': 'ab9c9bb9ca9aa'})[0]
         assert result.success is True
 
-        result = check.run({'title': 'ab9c9bb9-ca9aa'})
+        result = check.run({'title': 'ab9c9bb9-ca9aa'})[0]
         assert result.success is False
         assert result.error_code == ERROR_INVALID_PR_TITLE
 
-        result = check.run({'title': 'db9c9bb9ca9aa'})
+        result = check.run({'title': 'db9c9bb9ca9aa'})[0]
         assert result.success is False
         assert result.error_code == ERROR_INVALID_PR_TITLE
 
     def test_missing_title_returns_error(self):
         check = PRTitleCheck(CheckConfig('title', 'error'))
-        result = check.run({})  # no 'title' entry
+        result = check.run({})[0]  # no 'title' entry
         assert result.status == STATUS_ERROR
         assert result.error_code == ERROR_INVALID_CONTENT
         assert result.details['message'] == 'PR title not defined or empty'
 
     def test_missing_pattern_returns_error(self):
         check = PRTitleCheck(CheckConfig('title', 'error', pattern=''))
-        result = check.run({'title': 'My title'})
+        result = check.run({'title': 'My title'})[0]
         assert result.status == STATUS_ERROR
         assert result.error_code == ERROR_INVALID_CONFIG
         assert (
@@ -131,17 +131,17 @@ class TestPRBodyChecklist:
     def test_all(self):
         check = PRBodyChecklistCheck(CheckConfig('whatever', 'error'))
 
-        result = check.run({'body': 'This is something. \n- [x]\n- [x]\n\n* [x]'})
+        result = check.run({'body': 'This is something. \n- [x]\n- [x]\n\n* [x]'})[0]
         assert result.success is True
 
-        result = check.run({'body': 'This is something. \n- []'})
+        result = check.run({'body': 'This is something. \n- []'})[0]
         assert result.success is True
 
-        result = check.run({'body': 'This is something. \n- [ ]\n- [x]\n\n* [x]'})
+        result = check.run({'body': 'This is something. \n- [ ]\n- [x]\n\n* [x]'})[0]
         assert result.success is False
         assert result.error_code == ERROR_UNFINISHED_CHECKLIST
 
-        result = check.run({'body': 'This is something. \n- [x]\n- [x]\n\n* [ ]'})
+        result = check.run({'body': 'This is something. \n- [x]\n- [x]\n\n* [ ]'})[0]
         assert result.success is False
         assert result.error_code == ERROR_UNFINISHED_CHECKLIST
 
@@ -154,21 +154,21 @@ class TestPRBodyIncludes:
             CheckConfig('whatever', 'error', patterns=['must-be', 'present'])
         )
 
-        result = check.run({'body': 'Things must-be present'})
+        result = check.run({'body': 'Things must-be present'})[0]
         assert result.success is True
 
-        result = check.run({'body': 'A good present is a must-be'})
+        result = check.run({'body': 'A good present is a must-be'})[0]
         assert result.success is True
 
-        result = check.run({'body': 'present must be'})
+        result = check.run({'body': 'present must be'})[0]
         assert result.success is False
         assert result.error_code == ERROR_MISSING_PR_BODY_TEXT
 
-        result = check.run({'body': 'must-be pres-ent'})
+        result = check.run({'body': 'must-be pres-ent'})[0]
         assert result.success is False
         assert result.error_code == ERROR_MISSING_PR_BODY_TEXT
 
-        result = check.run({'body': 'totally unrelated'})
+        result = check.run({'body': 'totally unrelated'})[0]
         assert result.success is False
         assert result.error_code == ERROR_MISSING_PR_BODY_TEXT
 
@@ -181,18 +181,18 @@ class TestPRBodyExcludes:
             CheckConfig('whatever', 'error', patterns=['forbidden', 'fruit'])
         )
 
-        result = check.run({'body': 'Something about something else'})
+        result = check.run({'body': 'Something about something else'})[0]
         assert result.success is True
 
-        result = check.run({'body': 'I love eating fruit'})
+        result = check.run({'body': 'I love eating fruit'})[0]
         assert result.success is False
         assert result.error_code == ERROR_FORBIDDEN_PR_BODY_TEXT
 
-        result = check.run({'body': 'This is forbidden'})
+        result = check.run({'body': 'This is forbidden'})[0]
         assert result.success is False
         assert result.error_code == ERROR_FORBIDDEN_PR_BODY_TEXT
 
-        result = check.run({'body': 'Fruit is forbidden here'})
+        result = check.run({'body': 'Fruit is forbidden here'})[0]
         assert result.success is False
         assert result.error_code == ERROR_FORBIDDEN_PR_BODY_TEXT
 
@@ -223,7 +223,7 @@ class TestCommitMessages:
                     },
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_default_at_threshold_pass(self, default_check):
@@ -239,7 +239,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_subject_too_long_fails(self, default_check):
@@ -249,7 +249,7 @@ class TestCommitMessages:
                     {'stats': {'total': 4}, 'message': 'X' * 51, 'sha': 'aa', 'url': ''}
                 ]
             }
-        )
+        )[0]
         assert result.success is False
 
     def test_subject_too_short_fails(self, default_check):
@@ -259,7 +259,7 @@ class TestCommitMessages:
                     {'stats': {'total': 4}, 'message': 'X' * 5, 'sha': 'aa', 'url': ''}
                 ]
             }
-        )
+        )[0]
         assert result.success is False
 
     def test_default_body_line_too_long_fails(self, default_check):
@@ -274,7 +274,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is False
 
     def test_default_too_many_changes_without_body_fails(self, default_check):
@@ -289,7 +289,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is False
 
     def test_default_many_changes_with_body_pass(self, default_check):
@@ -304,7 +304,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     @pytest.fixture
@@ -337,7 +337,7 @@ class TestCommitMessages:
                     },
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_custom_at_threshold_pass(self, custom_check):
@@ -359,11 +359,11 @@ class TestCommitMessages:
                     },
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_custom_subject_too_long_fails(self, custom_check):
-        result = custom_check.run(
+        results = custom_check.run(
             {
                 'commits': [
                     {'stats': {'total': 4}, 'message': 'X' * 2, 'sha': 'aa', 'url': ''},
@@ -371,10 +371,17 @@ class TestCommitMessages:
                 ]
             }
         )
-        assert result.success is False
+        assert results[0].success is False
+        assert 'error_subject_pattern' in results[0].details['errors'][0]
+        assert len(results[0].details['errors']) == 1
+
+        assert results[1].success is False
+        assert 'error_subject_pattern' in results[1].details['errors'][0]
+        assert 'error_subject_length' in results[1].details['errors'][0]
+        assert len(results[1].details['errors']) == 1
 
     def test_custom_body_line_too_long_fails(self, custom_check):
-        result = custom_check.run(
+        results = custom_check.run(
             {
                 'commits': [
                     {
@@ -392,28 +399,39 @@ class TestCommitMessages:
                 ]
             }
         )
-        assert result.success is False
+        assert results[0].success is False
+        assert 'error_subject_pattern' in results[0].details['errors'][0]
+        assert 'error_body_length' in results[0].details['errors'][0]
+        assert len(results[0].details['errors']) == 1
+
+        assert results[1].success is False
+        assert 'error_subject_pattern' in results[1].details['errors'][0]
+        assert len(results[1].details['errors']) == 1
 
     def test_custom_too_many_changes_without_body_fails(self, custom_check):
-        result = custom_check.run(
+        results = custom_check.run(
             {
                 'commits': [
                     {
                         'stats': {'total': 11},
-                        'message': '{}'.format('X' * 5),
+                        'message': 'subject\n\nsomething\nhahaha',
                         'sha': 'aa',
                         'url': '',
                     },
                     {
-                        'stats': {'total': 10},
-                        'message': '{}'.format('X' * 5),
+                        'stats': {'total': 3},
+                        'message': 'subj\n\nLine 1\nLine 2\nLine 3',
                         'sha': 'aa',
                         'url': '',
                     },
                 ]
             }
         )
-        assert result.success is False
+        assert results[0].success is False
+        assert 'error_smart_body_size' in results[0].details['errors'][0]
+        assert len(results[0].details['errors']) == 1
+
+        assert len(results) == 1
 
     def test_custom_many_changes_with_body_pass(self, custom_check):
         result = custom_check.run(
@@ -428,8 +446,9 @@ class TestCommitMessages:
                     {'stats': {'total': 4}, 'message': 'x' * 5, 'sha': 'aa', 'url': ''},
                 ]
             }
-        )
+        )[0]
         assert result.success is True
+        assert 'errors' not in result.details
 
     @pytest.fixture()
     def custom_config(self):
@@ -452,7 +471,7 @@ class TestCommitMessages:
                     {'stats': {'total': 2}, 'message': 'x' * 1, 'sha': 'aa', 'url': ''}
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_no_subject_max_length_option_ignored(self, custom_config):
@@ -471,7 +490,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_no_subject_pattern_option_ignored(self, custom_config):
@@ -485,7 +504,7 @@ class TestCommitMessages:
                     {'stats': {'total': 2}, 'message': 'A82%@$', 'sha': 'aa', 'url': ''}
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_no_body_max_line_length_option_ignored(self, custom_config):
@@ -504,7 +523,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_no_body_smart_require_min_body_lines_option_ignored(self, custom_config):
@@ -523,7 +542,7 @@ class TestCommitMessages:
                     }
                 ]
             }
-        )
+        )[0]
         assert result.success is True
 
     def test_missing_key_from_config_fails_with_error(self, custom_config):
@@ -531,8 +550,116 @@ class TestCommitMessages:
         the check should fail with an error."""
         del custom_config['subject']
         check = CommitMessagesCheck(CheckConfig('whatever', 'error', **custom_config))
-        result = check.run({'commits': [{'message': 'xxxxx', 'sha': 'aa', 'url': ''}]})
+        result = check.run({'commits': [{'message': 'xxxxx', 'sha': 'aa', 'url': ''}]})[
+            0
+        ]
+
         assert result.success is False
         assert result.status is 'error'
         assert result.error_code is 'invalid_content'
         assert "Missing key: 'stats'" in result.details['message']
+
+    def test_url_in_message_ignores_max_length(self, custom_check):
+        """Test that body lines with URLs ignore the max length limit."""
+        urls = (
+            'http://www.example.com',
+            'https://www.example.com',
+            'ftp://www.example.com',
+        )
+        for url in urls:
+            result = custom_check.run(
+                {
+                    'commits': [
+                        {
+                            'stats': {'total': 2},
+                            'message': 'subj\n\nThis is a long url: {}'.format(url),
+                            'sha': 'aa',
+                            'url': '',
+                        },
+                        {
+                            'stats': {'total': 2},
+                            'message': 'x' * 5,
+                            'sha': 'aa',
+                            'url': '',
+                        },
+                    ]
+                }
+            )[0]
+            assert result.success is True
+            assert 'errors' not in result.details
+
+    def test_invalid_url_formats_in_message_respect_max_length(self, custom_check):
+        """Test that invalid URLs, or those that do not follow a specific format
+        are not treated as a special case."""
+        urls = ('www.example.com', 'invalid:/www.example.com')
+        for url in urls:
+            result = custom_check.run(
+                {
+                    'commits': [
+                        {
+                            'stats': {'total': 2},
+                            'message': 'subj\n\nThis is a long url: {}'.format(url),
+                            'sha': 'aa',
+                            'url': '',
+                        },
+                        {
+                            'stats': {'total': 2},
+                            'message': 'x' * 5,
+                            'sha': 'aa',
+                            'url': '',
+                        },
+                    ]
+                }
+            )[0]
+            assert result.success is False
+            assert 'error_body_length' in result.details['errors'][0]
+            assert len(result.details['errors']) == 1
+
+    def test_global_ignore_flag_in_body_ignores_all_errors(self, custom_check):
+        result = custom_check.run(
+            {
+                'commits': [
+                    {
+                        'stats': {'total': 2},
+                        'message': 'SUBJECT IS CAPS AND TOO LONG\n\n[!totem]',
+                        'sha': 'aa',
+                        'url': '',
+                    }
+                ]
+            }
+        )[0]
+        assert result.success is True
+        assert 'errors' not in result.details
+
+    def test_global_ignore_flag_in_subject_does_nothing(self, custom_check):
+        result = custom_check.run(
+            {
+                'commits': [
+                    {
+                        'stats': {'total': 2},
+                        'message': 'SUBJECT IS CAPS AND TOO LONG[!totem]',
+                        'sha': 'aa',
+                        'url': '',
+                    }
+                ]
+            }
+        )[0]
+        assert result.success is False
+        assert 'error_subject_length' in result.details['errors'][0]
+        assert len(result.details['errors']) == 1
+
+    def test_line_ignore_flag_ignores_line_errors(self, custom_check):
+        result = custom_check.run(
+            {
+                'commits': [
+                    {
+                        'stats': {'total': 2},
+                        'message': 'subj\n\nThis is a very long line indeed!! #!totem',
+                        'sha': 'aa',
+                        'url': '',
+                    }
+                ]
+            }
+        )[0]
+        assert result.success is True
+        assert 'errors' not in result.details

--- a/tests/checks/test_config.py
+++ b/tests/checks/test_config.py
@@ -1,5 +1,5 @@
 from totem.checks.checks import PR_TYPES_CHECKS
-from totem.checks.config import Config, ConfigFactory
+from totem.checks.config import CheckConfig, Config, ConfigFactory
 
 
 class TestConfig:
@@ -7,14 +7,14 @@ class TestConfig:
 
     def test_constructor(self):
         settings = {'doesnt': 'matter'}
-        check_configs = {'doesnt': 'matter'}
+        check_configs = [CheckConfig({'doesnt': 'matter'}, 'error')]
         config = Config(settings, check_configs)
 
         assert config.settings == settings
         assert config.check_configs == check_configs
 
     def test_default_pr_comment_report_property(self):
-        config = Config({}, {})
+        config = Config({}, [])
         assert config.pr_comment_report == {
             'enabled': True,
             'show_message': True,
@@ -23,7 +23,7 @@ class TestConfig:
         }
 
     def test_default_pr_console_report_property(self):
-        config = Config({}, {})
+        config = Config({}, [])
         assert config.pr_console_report == {
             'show_message': True,
             'show_empty_sections': True,
@@ -32,7 +32,7 @@ class TestConfig:
         }
 
     def test_default_local_console_report_property(self):
-        config = Config({}, {})
+        config = Config({}, [])
         assert config.local_console_report == {
             'show_message': True,
             'show_empty_sections': False,
@@ -42,7 +42,7 @@ class TestConfig:
 
     def test_pr_comment_property(self):
         settings = {'pr_comment_report': {'doesnt': 'matter'}}
-        config = Config(settings, {})
+        config = Config(settings, [])
         assert config.pr_comment_report == settings['pr_comment_report']
 
 
@@ -74,12 +74,12 @@ class TestConfigFactory:
         # Test checks
         check_configs = config.check_configs
 
-        branch_name = check_configs['branch_name']
+        branch_name = check_configs[0]
         assert branch_name.check_type == 'branch_name'
         assert branch_name.failure_level == 'warning'
         assert branch_name.options == {'pattern': '^TX-[0-9]+\-[\w\d\-]+$'}
 
-        doesnt_matter = check_configs['doesnt_matter']
+        doesnt_matter = check_configs[1]
         assert doesnt_matter.check_type == 'doesnt_matter'
         assert doesnt_matter.failure_level == 'error'
         assert doesnt_matter.options == {}
@@ -114,13 +114,12 @@ class TestConfigFactory:
 
         # Test checks
         check_configs = config.check_configs
-
-        branch_name = check_configs['branch_name']
+        branch_name = check_configs[0]
         assert branch_name.check_type == 'branch_name'
         assert branch_name.failure_level == 'warning'
         assert branch_name.options == {'pattern': '^TX-[0-9]+\-[\w\d\-]+$'}
 
-        doesnt_matter = check_configs['doesnt_matter']
+        doesnt_matter = check_configs[1]
         assert doesnt_matter.check_type == 'doesnt_matter'
         assert doesnt_matter.failure_level == 'error'
         assert doesnt_matter.options == {}

--- a/totem/checks/checks.py
+++ b/totem/checks/checks.py
@@ -396,7 +396,7 @@ class CommitMessagesCheck(Check):
                 # Otherwise, and if URLs should be ignored, only accept lines with URLs
                 return ignore_urls and url_pattern.search(line) is not None
 
-            url_pattern = re.compile('https?|ftp|mailto://')
+            url_pattern = re.compile('https?|ftp://')
             body_length_ok = all([check_line(line) for line in body_lines])
 
         # Smart check body: if there are a lot of changes on a commit

--- a/totem/checks/checks.py
+++ b/totem/checks/checks.py
@@ -364,10 +364,27 @@ class CommitMessagesCheck(Check):
         # Check body line length
         body_config = self._from_config('body')
         max_line_length = body_config.get('max_line_length', None)
+
+        # Don't check max length
         if max_line_length is None:
             body_length_ok = True
+
+        # Do check max length per line
+        # If ignore_urls is True, ignore lines that have a part that looks like
+        # a URL
         else:
-            body_length_ok = all([len(x) <= max_line_length for x in body_lines])
+            ignore_urls = body_config.get('ignore_urls', True)
+            url_pattern = re.compile('https?|ftp|mailto://')
+            body_length_ok = all(
+                [
+                    (
+                        len(x) <= max_line_length
+                        if url_pattern.search(x) is None
+                        else ignore_urls is True
+                    )
+                    for x in body_lines
+                ]
+            )
 
         # Smart check body: if there are a lot of changes on a commit
         # there should be a body, not just a subject

--- a/totem/checks/core.py
+++ b/totem/checks/core.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import List, Type, Union
 
 from totem.checks.config import CheckConfig
 from totem.checks.results import STATUS_ERROR, STATUS_FAIL, STATUS_PASS, CheckResult
@@ -25,13 +25,13 @@ class Check:
         """
         self._config = config
 
-    def run(self, content: dict) -> CheckResult:
+    def run(self, content: dict) -> List[CheckResult]:
         """Execute the check for the current parameters and return the result.
 
         :param dict content: contains parameters with the actual content to check,
             e.g. the commit message string for a checker that deals with commit messages
         :return: the result of performing the check
-        :rtype: CheckResult
+        :rtype: List[CheckResult]
         """
         raise NotImplementedError()
 
@@ -65,12 +65,19 @@ class Check:
         """
         return CheckResult(self._config, STATUS_PASS, **details)
 
-    def _get_failure(self, error_code: str, message: str, **details) -> CheckResult:
+    def _get_failure(
+        self, error_code: str, message: str, custom_level: str = None, **details
+    ) -> CheckResult:
         """Return a failed result.
 
         This means that the check was executed and failed."""
         return CheckResult(
-            self._config, STATUS_FAIL, error_code=error_code, message=message, **details
+            self._config,
+            STATUS_FAIL,
+            error_code=error_code,
+            message=message,
+            custom_level=custom_level,
+            **details,
         )
 
     def _get_error(self, error_code: str, message: str, **details) -> CheckResult:

--- a/totem/checks/results.py
+++ b/totem/checks/results.py
@@ -22,7 +22,12 @@ class CheckResult:
     """Contains the results of a single Check that was performed."""
 
     def __init__(
-        self, config: CheckConfig, status: str, error_code: str = None, **details
+        self,
+        config: CheckConfig,
+        status: str,
+        error_code: str = None,
+        custom_level: str = None,
+        **details
     ):
         """Constructor.
 
@@ -35,6 +40,7 @@ class CheckResult:
         self.config = config
         self.status = status
         self.error_code = error_code
+        self.custom_level = custom_level
         self.details = details
 
     @property
@@ -49,7 +55,11 @@ class CheckResult:
 
         For example, if it should block merging or just show a warning message.
         """
-        return self.config.failure_level
+        return (
+            self.custom_level
+            if self.custom_level is not None
+            else self.config.failure_level
+        )
 
     def __str__(self) -> str:
         return 'CheckResult type={}, status={}, error_code={}, details={}'.format(

--- a/totem/checks/suite.py
+++ b/totem/checks/suite.py
@@ -29,6 +29,7 @@ class CheckSuite:
         config: Config,
         content_provider_factory: BaseGitContentProviderFactory,
         check_factory: CheckFactory,
+        checks: List[str] = None,
     ):
         """Constructor.
 
@@ -38,10 +39,13 @@ class CheckSuite:
             knows how to create content providers for a specific Git service
         :param CheckFactory check_factory: an object that knows how to create
             Check subclasses for every known configuration type
+        :param List[str] checks: a list of IDs of checks to include in this run
         """
         self._content_provider_factory = content_provider_factory
         self._check_factory = check_factory
         self.config = config
+
+        self.included_check_ids = checks or self.config.check_configs.keys()
         self.results = CheckSuiteResults()
 
     def run(self):
@@ -51,6 +55,10 @@ class CheckSuite:
         This is the main point of the application where the actual magic happens.
         """
         for check_type, config in self.config.check_configs.items():
+            if check_type not in self.included_check_ids:
+                print('Ignoring check "{}"'.format(check_type))
+                continue
+
             results = self._run_check(config, self._check_factory)
             for r in results:
                 self.results.add(r)

--- a/totem/checks/suite.py
+++ b/totem/checks/suite.py
@@ -45,7 +45,7 @@ class CheckSuite:
         self._check_factory = check_factory
         self.config = config
 
-        self.included_check_ids = checks or self.config.check_configs.keys()
+        self.included_check_ids = checks or self.config.check_config_types
         self.results = CheckSuiteResults()
 
     def run(self):
@@ -54,7 +54,8 @@ class CheckSuite:
         Checks are executed synchronously, one by one.
         This is the main point of the application where the actual magic happens.
         """
-        for check_type, config in self.config.check_configs.items():
+        for config in self.config.check_configs:
+            check_type = config.check_type
             if check_type not in self.included_check_ids:
                 print('Ignoring check "{}"'.format(check_type))
                 continue

--- a/totem/checks/suite.py
+++ b/totem/checks/suite.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from totem.checks.config import CheckConfig, Config
 from totem.checks.content import BaseGitContentProviderFactory
 from totem.checks.core import CheckFactory
@@ -49,16 +51,19 @@ class CheckSuite:
         This is the main point of the application where the actual magic happens.
         """
         for check_type, config in self.config.check_configs.items():
-            result = self._run_check(config, self._check_factory)
-            self.results.add(result)
+            results = self._run_check(config, self._check_factory)
+            for r in results:
+                self.results.add(r)
 
-    def _run_check(self, config: CheckConfig, factory: CheckFactory) -> CheckResult:
+    def _run_check(
+        self, config: CheckConfig, factory: CheckFactory
+    ) -> List[CheckResult]:
         """Execute a check for the given configuration.
 
         :param CheckConfig config: the configuration of the check
         :param CheckFactory factory: the factory to use to create checks
-        :return: the result of the check
-        :rtype: CheckResult
+        :return: a list of CheckResult objects
+        :rtype: List
         """
         # For every configuration object a proper content provider
         # is created and then given to a check object that knows
@@ -69,7 +74,7 @@ class CheckSuite:
                 'Check with type "{}" could not be created. '
                 'Make sure that CheckFactory knows how to create it'
             ).format(config.check_type)
-            return CheckResult(config, STATUS_ERROR, ERROR_GENERIC, message=msg)
+            return [CheckResult(config, STATUS_ERROR, ERROR_GENERIC, message=msg)]
 
         try:
             content_provider = self._content_provider_factory.create(check)
@@ -82,8 +87,8 @@ class CheckSuite:
                     check.check_type, factory_type.__module__, factory_type.__name__
                 )
 
-                return CheckResult(config, STATUS_ERROR, ERROR_GENERIC, message=msg)
+                return [CheckResult(config, STATUS_ERROR, ERROR_GENERIC, message=msg)]
             content = content_provider.get_content()
             return check.run(content)
         except Exception as e:
-            return CheckResult(config, STATUS_ERROR, ERROR_GENERIC, message=str(e))
+            return [CheckResult(config, STATUS_ERROR, ERROR_GENERIC, message=str(e))]

--- a/totem/reporting/console.py
+++ b/totem/reporting/console.py
@@ -65,7 +65,7 @@ class BaseConsoleReport:
         :param Config config: the configuration that will be used
         :param str pr_url: the URL of the pull request
         """
-        check_types = config.check_configs.keys()
+        check_types = config.check_config_types
         builder = StringBuilder()
         builder.add()
         builder.add(


### PR DESCRIPTION
Make various improvements on how checks work.

## Ignore line length check for URLs
If a line includes a URL (something that has `http://`, `https://` or `ftp://`), this line is not checked for its length. All other lines are checked, as normal. This was introduced because often URLs are very long, and this prevent the line length check of commit messages to pass.

Introduce a configuration option that allows this behaviour: (`ignore_urls`) under `commit_message.body`, default is `True`.

## Add ignore flags for commit messages

Add flag that totally ignores commit message checks (`[!totem]`).
Add flag that ignores a specific line of a commit message body (`#!totem`).

## Allow CLI to run specific checks only
You can define which checks to run.

## Check each commit separately
All checks now can return multiple results, so now each commit is handled as a separate `CheckResult`, thus displaying the information more clearly.

## Allow multiple checks of the same type

The configuration file can now support 2 different structures
for checks, dictionaries and lists.

The new format (list) allows users to include more checks of the same
check type, with different options.

## Fix bug with # of commits in local mode

Before, the local mode only checked the last commit.
Now, all commits up to the first commit of the current branch
are checked.

