### PR TITLE
Fix dependency issue of gitdb.utils.compat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
         command: apk add git openssh-client && mkdir ~/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts
     - run:
         name: Install totem
-        command: pip install git+ssh://git@github.com/transifex/totem.git@devel
+        command: pip install .
     # The pull request string can be empty for 2 reasons:
     #   1. This is a merge commit, so there is currently no PR
     #   2. A bug of CircleCI does not populate the PR variable

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Click',
         'PyGitHub==1.40a4',
         'pyaml==17.12.1',
-        'GitPython==2.1.11',
+        'GitPython==3.0.8',
     ],
     py_modules=['cli'],
     entry_points={'console_scripts': ['totem=cli:main']},


### PR DESCRIPTION
Fix a ModuleNotFoundError that occurred because of
https://github.com/gitpython-developers/GitPython/issues/983

Also make totem on CI run using its current state, not the `devel` branch.